### PR TITLE
fix: CHARGE entry round-trip with PDB-padded atom names (v1.3.10)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rdkit_to_params"
-version = "1.3.9"
+version = "1.3.10"
 description = "Create or modify Rosetta params files (topology files) from scratch, RDKit mols or another params file."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/rdkit_to_params/entries.py
+++ b/rdkit_to_params/entries.py
@@ -395,6 +395,7 @@ class PROTON_CHIEntry:
     Proton chi sampling specification for polar hydrogens (hydroxyl, thiol, amine).
     E.g. ``PROTON_CHI 3 SAMPLES 18 0 20 40 60 80 100 120 140 160 180 200 220 240 260 280 300 320 340 EXTRA 0``
     """
+
     chi_index: int
     samples: list[int]
     extra: list[int]
@@ -420,7 +421,7 @@ class PROTON_CHIEntry:
         n_samples = int(rex.group(2))
         samples = [int(x) for x in rex.group(3).split()]
         if len(samples) != n_samples:
-            raise ValueError(f'PROTON_CHI expected {n_samples} samples, got {len(samples)}')
+            raise ValueError(f"PROTON_CHI expected {n_samples} samples, got {len(samples)}")
         extra = [int(x) for x in rex.group(4).split()]
         return cls(chi_index=chi_index, samples=samples, extra=extra)
 
@@ -659,21 +660,33 @@ Entries.choices["CUT_BOND"] = (CUT_BONDEntry, Singletony.multiton)
 @dataclass
 class CHARGEEntry:
     """
-    No idea if anything respects this.
+    Per-atom formal charge entry, written by Rosetta as e.g.
+
+        CHARGE OA FORMAL -1
+
+    ``self.atom`` may be a PDB-padded atom name (4-char, e.g. ``" OA "``)
+    or pre-stripped — the dump strips so that the on-disk format always
+    has single-space separators (round-trip-safe with ``from_str``).
     """
 
     atom: str
-    charge: str  # e.g. "+1" or "-1"
+    charge: str  # e.g. "+1", "-1", "-12"
 
     def __str__(self) -> str:
-        return f"CHARGE {self.atom} FORMAL {self.charge}"
+        # ↓ Strip the atom name on dump so multi-space PDB padding doesn't
+        #   sneak into the output and break re-parsing. See from_str regex.
+        return f"CHARGE {self.atom.strip()} FORMAL {self.charge}"
 
     def _repr_html_(self):
         return f"{html_span('CHARGE')} {self.atom} {html_span(self.charge)}"
 
     @classmethod
     def from_str(cls, text: str):
-        rex = re.match(r"(?P<atom>\S+) FORMAL (?P<charge>\-?\+?\d)", text.rstrip())
+        # ↓ Tolerate any whitespace between the three tokens (PDB-padded
+        #   atom names produce multi-space gaps after the bare ``__str__``
+        #   join). Sign is one of ``+/-`` (or none); charge digits are
+        #   one-or-more so multi-digit charges (e.g. ``-12``) parse too.
+        rex = re.match(r"(?P<atom>\S+)\s+FORMAL\s+(?P<charge>[+-]?\d+)", text.rstrip())
         if rex is None:
             raise ValueError(f'CHARGE entry "{text}" is not formatted correctly')
         data = rex.groupdict()
@@ -808,6 +821,7 @@ class RAMA_PREPRO_FILENAMEEntry:
     Two database-relative paths: the general table and the pre-proline table.
     E.g. ``RAMA_PREPRO_FILENAME scoring/…/AIB_general.rama scoring/…/AIB_prepro.rama``
     """
+
     general: str
     prepro: str
 
@@ -824,9 +838,7 @@ class RAMA_PREPRO_FILENAMEEntry:
         return f"RAMA_PREPRO_FILENAME {self.general} {self.prepro}"
 
     def _repr_html_(self):
-        return (
-            f"{html_span('RAMA_PREPRO_FILENAME')} general:{self.general} prepro:{self.prepro}"
-        )
+        return f"{html_span('RAMA_PREPRO_FILENAME')} general:{self.general} prepro:{self.prepro}"
 
     @classmethod
     def from_str(cls, text: str):
@@ -854,6 +866,7 @@ class RAMA_PREPRO_RESNAMEEntry(GenericEntry):
 
     E.g. ``RAMA_PREPRO_RESNAME GENERIC_ALPHA_AMINOISOBUTYRIC_AA``
     """
+
     def __init__(self, body: str):
         super().__init__(header="RAMA_PREPRO_RESNAME", body=body)
 
@@ -1124,6 +1137,7 @@ class NUMERIC_PROPERTYEntry:
     Numeric property for a residue type, e.g. ``NUMERIC_PROPERTY REFERENCE -1.5``.
     Used by Rosetta score terms like ``ref_nc`` to assign reference energies to ncAAs.
     """
+
     tag: str
     value: float
 
@@ -1137,7 +1151,9 @@ class NUMERIC_PROPERTYEntry:
     def from_str(cls, text: str):
         parts = text.split(None, 1)
         if len(parts) != 2:
-            raise ValueError(f'NUMERIC_PROPERTY entry "{text}" should have a tag and a numeric value')
+            raise ValueError(
+                f'NUMERIC_PROPERTY entry "{text}" should have a tag and a numeric value'
+            )
         return cls(tag=parts[0], value=float(parts[1]))
 
 
@@ -1152,6 +1168,7 @@ class STRING_PROPERTYEntry:
     """
     String property for a residue type, e.g. ``STRING_PROPERTY SOME_TAG some_value``.
     """
+
     tag: str
     value: str
 

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,4 +1,5 @@
 """Test internal functionality of rdkit_to_params package."""
+
 import re
 from pathlib import Path
 
@@ -190,6 +191,38 @@ class TestCHARGEEntry:
         assert entry.atom == "OD1"
         assert entry.charge == "-1"
 
+    def test_charge_entry_from_str_multi_space(self):
+        """Multi-space gaps within the body (as produced by the bare
+        f-string dump when ``self.atom`` carries PDB-style padding —
+        e.g. ``CHARGE OA   FORMAL -1``, body becomes ``OA   FORMAL -1``)
+        must round-trip cleanly.
+        """
+        text = "OA   FORMAL  -1"
+        entry = CHARGEEntry.from_str(text)
+        assert entry.atom == "OA"
+        assert entry.charge == "-1"
+
+    def test_charge_entry_from_str_multi_digit(self):
+        """Multi-digit formal charges (e.g. ``-12``) must parse."""
+        entry = CHARGEEntry.from_str("FE FORMAL -12")
+        assert entry.atom == "FE"
+        assert entry.charge == "-12"
+
+    def test_charge_entry_str_strips_padding(self):
+        """``__str__`` must emit a single-space-separated line even when the
+        atom name carries PDB-style 4-char padding — otherwise the result
+        is unparseable by ``from_str``.
+        """
+        entry = CHARGEEntry(atom=" OA ", charge="-1")
+        assert str(entry) == "CHARGE OA FORMAL -1"
+
+    def test_charge_entry_roundtrip_padded(self):
+        """Padded-atom dump → load → equal atom (stripped) and charge."""
+        original = CHARGEEntry(atom=" OA ", charge="-1")
+        reparsed = CHARGEEntry.from_str(str(original).removeprefix("CHARGE "))
+        assert reparsed.atom == "OA"
+        assert reparsed.charge == "-1"
+
 
 class TestIO_STRINGEntry:
     """Test IO_STRING entry parsing."""
@@ -232,17 +265,14 @@ class TestParamsInit:
         """Test creating an empty Params instance."""
         params = Params()
         assert isinstance(params, Params)
-        assert hasattr(params, 'ATOM')
-        assert hasattr(params, 'BOND')
-        assert hasattr(params, 'CHI')
+        assert hasattr(params, "ATOM")
+        assert hasattr(params, "BOND")
+        assert hasattr(params, "CHI")
 
     def test_params_has_attributes(self):
         """Test that Params has expected attributes."""
         params = Params()
-        expected_attrs = [
-            'ATOM', 'BOND', 'CHI', 'ICOOR_INTERNAL',
-            'IO_STRING', 'CONNECT', 'NAME'
-        ]
+        expected_attrs = ["ATOM", "BOND", "CHI", "ICOOR_INTERNAL", "IO_STRING", "CONNECT", "NAME"]
         for attr in expected_attrs:
             assert hasattr(params, attr), f"Missing attribute: {attr}"
 
@@ -330,14 +360,14 @@ class TestParamsAtomRenaming:
         params = Params.load(str(official_phe_params))
 
         # Find a bond with CA
-        ca_bonds_before = [b for b in params.BOND if ' CA ' in (b.first, b.second)]
+        ca_bonds_before = [b for b in params.BOND if " CA " in (b.first, b.second)]
         assert len(ca_bonds_before) > 0, "PHE should have bonds with CA"
 
         params.rename_atom(" CA ", " CX ")
 
         # CA should be gone, CX should exist
-        ca_bonds_after = [b for b in params.BOND if ' CA ' in (b.first, b.second)]
-        cx_bonds_after = [b for b in params.BOND if ' CX ' in (b.first, b.second)]
+        ca_bonds_after = [b for b in params.BOND if " CA " in (b.first, b.second)]
+        cx_bonds_after = [b for b in params.BOND if " CX " in (b.first, b.second)]
 
         assert len(ca_bonds_after) == 0
         assert len(cx_bonds_after) == len(ca_bonds_before)
@@ -347,17 +377,20 @@ class TestParamsAtomRenaming:
         params = Params.load(str(official_phe_params))
 
         # Find CHI entries with CA
-        chi_with_ca_before = sum(1 for chi in params.CHI
-                                  if ' CA ' in (chi.first, chi.second, chi.third, chi.fourth))
+        chi_with_ca_before = sum(
+            1 for chi in params.CHI if " CA " in (chi.first, chi.second, chi.third, chi.fourth)
+        )
 
         if chi_with_ca_before > 0:
             params.rename_atom(" CA ", " CX ")
 
             # CA should be replaced with CX
-            chi_with_ca_after = sum(1 for chi in params.CHI
-                                     if ' CA ' in (chi.first, chi.second, chi.third, chi.fourth))
-            chi_with_cx_after = sum(1 for chi in params.CHI
-                                     if ' CX ' in (chi.first, chi.second, chi.third, chi.fourth))
+            chi_with_ca_after = sum(
+                1 for chi in params.CHI if " CA " in (chi.first, chi.second, chi.third, chi.fourth)
+            )
+            chi_with_cx_after = sum(
+                1 for chi in params.CHI if " CX " in (chi.first, chi.second, chi.third, chi.fourth)
+            )
 
             assert chi_with_ca_after == 0
             assert chi_with_cx_after == chi_with_ca_before
@@ -371,7 +404,6 @@ class TestParamsAtomRenaming:
         assert params.get_correct_atomname(" CA") == " CA "
         assert params.get_correct_atomname("CA ") == " CA "
         assert params.get_correct_atomname(" CA ") == " CA "
-
 
 
 class TestParamsFields:
@@ -392,9 +424,9 @@ class TestParamsFields:
         params = Params.load(str(official_phe_params))
 
         # These should all work
-        assert hasattr(params, 'ATOM')
-        assert hasattr(params, 'BOND')
-        assert hasattr(params, 'NAME')
+        assert hasattr(params, "ATOM")
+        assert hasattr(params, "BOND")
+        assert hasattr(params, "NAME")
 
 
 class TestParamsComments:
@@ -424,7 +456,9 @@ class TestRegexPatterns:
 
     def test_atom_pattern_matches(self):
         """Test ATOM entry regex pattern."""
-        pattern = r"(?P<name>.{1,4})\s*(?P<rtype>.{1,4})\s*(?P<mtype>.{1,4})\s*(?P<partial>[-\d\.]+)"
+        pattern = (
+            r"(?P<name>.{1,4})\s*(?P<rtype>.{1,4})\s*(?P<mtype>.{1,4})\s*(?P<partial>[-\d\.]+)"
+        )
         text = " CA  CT1 CT  0.07"
         match = re.match(pattern, text.rstrip())
         assert match is not None
@@ -448,12 +482,23 @@ class TestRegexPatterns:
         assert match.group(1) == "1"
 
     def test_charge_pattern_matches(self):
-        """Test CHARGE entry regex pattern."""
-        pattern = r"(?P<atom>\S+) FORMAL (?P<charge>\-?\+?\d)"
+        """Test CHARGE entry regex pattern.
+
+        Tolerant of any whitespace between tokens (so PDB-padded atom
+        names round-trip after ``__str__``) and accepts multi-digit
+        signed charges.
+        """
+        pattern = r"(?P<atom>\S+)\s+FORMAL\s+(?P<charge>[+-]?\d+)"
         text = "NZ FORMAL +1"
         match = re.match(pattern, text.rstrip())
         assert match is not None
         assert match.group("charge") == "+1"
+
+        text = "OA   FORMAL  -12"
+        match = re.match(pattern, text.rstrip())
+        assert match is not None
+        assert match.group("atom") == "OA"
+        assert match.group("charge") == "-12"
 
 
 class TestParamsIntegration:
@@ -487,15 +532,15 @@ class TestParamsIntegration:
         params = Params.load(str(official_phe_params))
 
         # Get original bond involving CA
-        ca_bonds = [b for b in params.BOND if ' CA ' in (b.first, b.second)]
+        ca_bonds = [b for b in params.BOND if " CA " in (b.first, b.second)]
         assert len(ca_bonds) > 0
 
         # Rename CA to CX
-        params.rename_atom(' CA ', ' CX ')
+        params.rename_atom(" CA ", " CX ")
 
         # Verify all CA references are now CX
-        ca_bonds_after = [b for b in params.BOND if ' CA ' in (b.first, b.second)]
-        cx_bonds_after = [b for b in params.BOND if ' CX ' in (b.first, b.second)]
+        ca_bonds_after = [b for b in params.BOND if " CA " in (b.first, b.second)]
+        cx_bonds_after = [b for b in params.BOND if " CX " in (b.first, b.second)]
 
         assert len(ca_bonds_after) == 0
         assert len(cx_bonds_after) == len(ca_bonds)
@@ -533,7 +578,6 @@ class TestEdgeCases:
         # This should raise an error since ZZ doesn't exist
         with pytest.raises(ValueError, match="not a valid atom name"):
             params.rename_atom(" ZZ ", " XX ")
-
 
     def test_load_nonexistent_file(self):
         """Test loading a nonexistent file raises appropriate error."""
@@ -604,4 +648,3 @@ class TestOHIRoundtrip:
 
 
 # Run with: pytest tests/test_internals.py -v
-


### PR DESCRIPTION
## Summary

`CHARGEEntry.__str__` renders the f-string with `self.atom` verbatim, so PDB-padded atom names (e.g. `" OA "`) produce `CHARGE  OA   FORMAL -1` — multi-space gaps. The matching `CHARGEEntry.from_str` regex requires exactly one literal space between tokens, so the library cannot read back its own output for any molecule with a non-zero formal charge.

Surfaced while minting a Rosetta params file for a caprylate anion ligand: `Params.dump → Params.load` raised `ValueError: CHARGE entry "OA   FORMAL -1" is not formatted correctly`.

## Fix

Two-sided so existing `.params` files in the wild (single-space *or* multi-space, multi-digit charges) keep parsing while new dumps emit cleanly:

- **`__str__`** now strips `self.atom` on emit, so the dumped line is single-space separated regardless of input padding (e.g. `CHARGE OA FORMAL -1` rather than `CHARGE  OA   FORMAL -1`).
- **`from_str` regex** widened from `r"(?P<atom>\S+) FORMAL (?P<charge>\-?\+?\d)"` to `r"(?P<atom>\S+)\s+FORMAL\s+(?P<charge>[+-]?\d+)"` — tolerates any whitespace between tokens and accepts multi-digit signed charges (`-12`, `+10`, etc.). The cleaner `[+-]?` also rejects nonsense like `-+1` that the old `\-?\+?` accepted.

Version bump `1.3.9 → 1.3.10` (patch — bug fix, no API change).

## Tests

Added to `TestCHARGEEntry` and `TestRegexPatterns`:

- `test_charge_entry_from_str_multi_space` — `"OA   FORMAL  -1"` parses cleanly.
- `test_charge_entry_from_str_multi_digit` — `"FE FORMAL -12"` parses cleanly.
- `test_charge_entry_str_strips_padding` — `CHARGEEntry(atom=" OA ", charge="-1")` emits `"CHARGE OA FORMAL -1"`.
- `test_charge_entry_roundtrip_padded` — `CHARGEEntry(atom=" OA ", charge="-1") → str → from_str → CHARGEEntry(atom="OA", charge="-1")`.
- `test_charge_pattern_matches` extended with the multi-space / multi-digit case.

`pytest tests/test_internals.py` — 57 passed (50 unrelated + 7 in `TestCHARGEEntry`).
`ruff check rdkit_to_params/entries.py` — clean.
`ruff format` — applied to touched files.

## Test plan

- [x] `pytest tests/test_internals.py` passes
- [x] `ruff check rdkit_to_params/entries.py` clean
- [x] `ruff format --check` clean on touched files